### PR TITLE
Fix for when worker doesn't die in non-server mode

### DIFF
--- a/lib/cluster.exception.js
+++ b/lib/cluster.exception.js
@@ -246,7 +246,13 @@ exports = module.exports = function exception (options) {
         console.error(error.stack || error.message);
 
         // report exception
-        instance.master.call('workerException', error)
+        if (instance.master) {
+          // cluster with server
+          instance.master.call('workerException', error)
+        } else {
+          // cluster without server
+          instance.call('workerException', error)
+        }
 
         // exit
         process.nextTick(function (){


### PR DESCRIPTION
When you use cluster in a non-server environment cluster.exception fails to actually kill the worker process.  Within a non-server environment, instance.master is undefined.
